### PR TITLE
Make memcache not verbose by default

### DIFF
--- a/templates/default/memcached.conf.erb
+++ b/templates/default/memcached.conf.erb
@@ -15,7 +15,7 @@
 logfile /var/log/memcached.log
 
 # Be verbose
--v
+# -v
 
 # Be even more verbose (print client commands as well)
 # -vv


### PR DESCRIPTION
I know this is not the policy for this project, but I just wanted to report that letting memcache run in verbose by default is not a great idea and can harm a lot… Or ate least add a parameter to change it.