### PR TITLE
COOK-4561 - Fixed debian/ubuntu user selection

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,12 +29,15 @@ case node['platform_family']
 when 'suse', 'fedora', 'rhel'
   default['memcached']['user'] = 'memcached'
   default['memcached']['group'] = 'memcached'
-when 'ubuntu'
-  default['memcached']['user'] = 'memcache'
-  default['memcached']['group'] = 'memcache'
 when 'debian'
-  default['memcached']['user'] = 'nobody'
-  default['memcached']['group'] = 'nogroup'
+  case node['platform']
+  when 'ubuntu'
+    default['memcached']['user'] = 'memcache'
+    default['memcached']['group'] = 'memcache'
+  when 'debian'
+    default['memcached']['user'] = 'nobody'
+    default['memcached']['group'] = 'nogroup'
+  end
 else
   default['memcached']['user'] = 'nobody'
   default['memcached']['user'] = 'nogroup'


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4561

The default user attribute for user and group does not get properly set properly by using `platform_family` being set to `ubuntu` and `debian`. I've set the condition of `platform_family` to `debian` and then differentiated between debian and ubuntu with `platform`.