### PR TITLE
Always use the default values of Debian if you have memcached enabled.

### DIFF
--- a/templates/default/memcached.conf.erb
+++ b/templates/default/memcached.conf.erb
@@ -23,11 +23,17 @@ logfile /var/log/memcached.log
 # Start with a cap of 64 megs of memory. It's reasonable, and the daemon default
 # Note that the daemon will grow to this size, but does not start out holding this much
 # memory
+<%- if @memory %>
 -m <%= @memory %>
+<%- if @memory %>
 
 # Default connection port is 11211
+<%- if @port %>
 -p <%= @port %>
+<%- end %>
+<%- if @udp_port %>
 -U <%= @udp_port %>
+<%- end %>
 
 # Run the daemon as root. The start-memcached will default to running as root if no
 # -u command is present in this config file
@@ -36,10 +42,14 @@ logfile /var/log/memcached.log
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
 # it's listening on a firewalled interface.
+<%- if @listen %>
 -l <%= @listen %>
+<%- end %>
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
+<%- if @maxconn %>
 -c <%= @maxconn %>
+<%- end %>
 
 # Lock down all paged memory. Consult with the README and homepage before you do this
 # -k
@@ -51,4 +61,6 @@ logfile /var/log/memcached.log
 # -r
 
 # Max object size
+<%- if @max_object_size %>
 -I <%= @max_object_size %>
+<%- end %>


### PR DESCRIPTION
Some options, like UDP ports, memory usage etc are not needed. You need to be able to start memcached without any configuration, just as Debian/Ubuntu allows you if you setup memcached. You can override each bit by a recipe/node configuration.