### PR TITLE
Fix Memcached user on Debian and/or Ubuntu, or add if missing.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,13 +31,10 @@ case node['platform_family']
 when 'suse', 'fedora', 'rhel'
   default['memcached']['user'] = 'memcached'
   default['memcached']['group'] = 'memcached'
-when 'ubuntu'
+when 'debian'
   default['memcached']['user'] = 'memcache'
   default['memcached']['group'] = 'memcache'
-when 'debian'
-  default['memcached']['user'] = 'nobody'
-  default['memcached']['group'] = 'nogroup'
 else
   default['memcached']['user'] = 'nobody'
-  default['memcached']['user'] = 'nogroup'
+  default['memcached']['group'] = 'nogroup'
 end

--- a/test/integration/instance/serverspec/instance_spec.rb
+++ b/test/integration/instance/serverspec/instance_spec.rb
@@ -11,7 +11,7 @@ describe service('memcached') do
 end
 
 describe command('service memcached status') do
-  its(:stdout) { should match /^run: memcached/ }
+  its(:stdout) { should match(/^run: memcached/) }
 end
 
 describe port(11_212) do


### PR DESCRIPTION
This is to fix the default user on Debian and/or Ubuntu which used to be the
`nobody` user, but that since has changed, as per:

  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=587797
  - https://launchpad.net/ubuntu/+source/memcached/1.4.13-0.1ubuntu1

Nowadays, packages on both Debian and Ubuntu (and most likely their derivatives)
would create dedicated `memcache` user. Nonetheless, we attempt to create
a dedicated user in case there isn't one already.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>