### PR TITLE
fixes chef 13 deprecation warnings

### DIFF
--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -23,11 +23,11 @@ property :port, [Integer, String], default: 11_211
 property :udp_port, [Integer, String], default: 11_211
 property :listen, String, default: '0.0.0.0'
 property :maxconn, [Integer, String], default: 1024
-property :user, String, default: nil
-property :threads, [Integer, String], default: nil
+property :user, [String, nil], default: nil
+property :threads, [Integer, String, nil], default: nil
 property :max_object_size, String, default: '1m'
 property :experimental_options, Array, default: []
-property :ulimit, [Integer, String], default: nil
+property :ulimit, [Integer, String, nil], default: nil
 property :template_cookbook, String, default: 'memcached'
 
 action :create do


### PR DESCRIPTION
this PR fixes deprecation warnings such as the one below, which apparently will become an error in chef 13

```
[2016-02-17T05:16:10+00:00] WARN: Default value nil is invalid for property user of resource memcached_instance. Possible fixes: 1. Remove 'default: nil' if nil means 'undefined'. 2. Set a valid default value if there is a reasonable one. 3. Allow nil as a valid value of your property (for example, 'property :user, [ String, nil ], default: nil'). Error: Property user must be one of: String!  You passed nil. at /var/chef/cache/cookbooks/memcached/resources/instance.rb:26:in `class_from_file'
```