### PR TITLE
Do not re-redeclare service[memcached]

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -66,6 +66,7 @@ end
 
 # Disable the default memcached service so we configure it from the custom resource
 # If the memcached::default is included the configure.rb recipe will start/enable the service
-service 'memcached' do
+service ':delete memcached' do
+  service_name 'memcached'
   action [:stop, :disable]
 end


### PR DESCRIPTION
Avoid re-declaring `service[memcache]` in recipe `memcached::default`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chef-cookbooks/memcached/63)
<!-- Reviewable:end -->
