### PR TITLE
Change expected type for ulimit attribute to match doc / templates

### DIFF
--- a/resources/instance.rb
+++ b/resources/instance.rb
@@ -27,7 +27,7 @@ property :user, String
 property :threads, [Integer, String]
 property :max_object_size, String, default: '1m'
 property :experimental_options, Array, default: []
-property :ulimit, [Integer, String]
+property :ulimit, [TrueClass]
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [TrueClass, FalseClass], default: true
 


### PR DESCRIPTION
Obvious fix? 

Cookbook as of 2.1.0 has restrictions ([Integer, String]) on the attribute type for ulimit (resources/instance.rb) which don't match the [documentation] (https://supermarket.chef.io/cookbooks/memcached#readme) nor expectation of the [service template] (https://github.com/chef-cookbooks/memcached/blob/master/templates/default/sv-memcached-run.erb). 

This causes the ulimit to not be set in the derived service file (/etc/service/bauhaus-memcached/run on Ubuntu).

