### PR TITLE
Support sys-v init on all platforms

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -59,7 +59,7 @@ platforms:
     image: fedora:latest
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN dnf -y install yum which net-tools chkconfig
+      - RUN dnf -y install yum which net-tools chkconfig passwd
 
 - name: ubuntu-12.04
   driver:

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -90,14 +90,14 @@ platforms:
     image: opensuse:13.2
     pid_one_command: /bin/systemd
     intermediate_instructions:
-      - RUN zypper --non-interactive install net-tools
+      - RUN zypper --non-interactive install net-tools aaa_base perl-Getopt-Long-Descriptive
 
 - name: opensuse-42.1
   driver:
     image: opensuse:42.1
     pid_one_command: /bin/systemd
     intermediate_instructions:
-      - RUN zypper --non-interactive install net-tools
+      - RUN zypper --non-interactive install net-tools aaa_base perl-Getopt-Long-Descriptive
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   - INSTANCE=default-ubuntu-1204
   - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
+  - INSTANCE=default-debian-7
   - INSTANCE=default-debian-8
   - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7
@@ -32,6 +33,7 @@ env:
   - INSTANCE=instance-ubuntu-1204
   - INSTANCE=instance-ubuntu-1404
   - INSTANCE=instance-ubuntu-1604
+  - INSTANCE=instance-debian-7
   - INSTANCE=instance-debian-8
   - INSTANCE=instance-centos-6
   - INSTANCE=instance-centos-7

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,13 +1,9 @@
 <!-- This is a generated file. Please do not edit directly -->
 
 # Maintainers
-This file lists how this cookbook project is maintained. When making changes to the system, this
-file tells you who needs to review your patch - you need a simple majority of maintainers
-for the relevant subsystems to provide a :+1: on your pull request. Additionally, you need
-to not receive a veto from a Lieutenant or the Project Lead.
+This file lists how this cookbook project is maintained. When making changes to the system, this file tells you who needs to review your patch - you need a review from an existing maintainer for the cookbook to provide a :+1: on your pull request. Additionally, you need to not receive a veto from a Lieutenant or the Project Lead.
 
-Check out [How Cookbooks are Maintained](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD) 
-for details on the process and how to become a maintainer or the project lead.
+Check out [How Cookbooks are Maintained](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD) for details on the process and how to become a maintainer or the project lead.
 
 # Project Maintainer
 * [Tim Smith](https://github.com/tas50)

--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -5,13 +5,10 @@
 [Preamble]
   title = "Maintainers"
   text = """
-This file lists how this cookbook project is maintained. When making changes to the system, this
-file tells you who needs to review your patch - you need a simple majority of maintainers
-for the relevant subsystems to provide a :+1: on your pull request. Additionally, you need
-to not receive a veto from a Lieutenant or the Project Lead.
 
-Check out [How Cookbooks are Maintained](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD) 
-for details on the process and how to become a maintainer or the project lead.
+This file lists how this cookbook project is maintained. When making changes to the system, this file tells you who needs to review your patch - you need a review from an existing maintainer for the cookbook to provide a :+1: on your pull request. Additionally, you need to not receive a veto from a Lieutenant or the Project Lead.
+
+Check out [How Cookbooks are Maintained](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD) for details on the process and how to become a maintainer or the project lead.
 """
 
 [Org]
@@ -20,7 +17,7 @@ for details on the process and how to become a maintainer or the project lead.
       title = "Project Maintainer"
 
       lieutenant = 'tas50'
-    
+
       maintainers = [
         'sigje',
         'tas50',

--- a/resources/instance_sysv_init.rb
+++ b/resources/instance_sysv_init.rb
@@ -114,6 +114,9 @@ action_class.class_eval do
     # the init script will not run without redhat-lsb packages
     package lsb_package if node['platform_family'] == 'rhel'
 
+    # chkconfig won't run without perl-Getopt-Long-Descriptive on suse
+    package 'perl-Getopt-Long-Descriptive' if node['platform_family'] == 'suse'
+
     template "/etc/init.d/#{memcached_instance_name}" do
       mode '0755'
       source 'init_sysv.erb'

--- a/templates/init_sysv.erb
+++ b/templates/init_sysv.erb
@@ -52,7 +52,7 @@ case $1 in
   log_daemon_msg "Starting the process" "$NAME"
   # Start the daemon with the help of start-stop-daemon
   # Log the message appropriately
-  if start-stop-daemon -m --start --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON -- -d <%= @cli_options %>; then
+  if start-stop-daemon -m --start --quiet --oknodo --pidfile $PIDFILE -b --exec $DAEMON -- <%= @cli_options %>; then
    log_end_msg 0
   else
    log_end_msg 1

--- a/templates/init_sysv.erb
+++ b/templates/init_sysv.erb
@@ -18,9 +18,6 @@
 
 ulimit -n <%= @ulimit %>
 
-## Source function library.
-. /etc/rc.d/init.d/functions
-
 # Source LSB function library.
 if [ -r /lib/lsb/init-functions ]; then
     . /lib/lsb/init-functions
@@ -29,65 +26,77 @@ else
     exit 1
 fi
 
-RETVAL=0
-prog="memcached"
+NAME=<%= @instance %>
+DAEMON=/usr/bin/memcached
+PIDFILE=/var/run/memcached/<%= @instance %>.pid
 
-start () {
-    echo -n $"Starting $prog: "
+test -x $DAEMON || exit 5
 
-    # ensure that /var/run/memcached actually exists (doesn't on debian by default)
-    if [ ! -d /var/run/memcached ]; then
-      mkdir /var/run/memcached
-    fi
+case $1 in
+ start)
 
-    # ensure that /var/run/memcached has proper permissions
-    if [ "`stat -c %U /var/run/memcached`" != "<%= @user %>" ]; then
-        chown <%= @user %> /var/run/memcached
-    fi
+  # make sure the PID dir is actually there
+  if [ ! -d /var/run/memcached ]; then
+    mkdir /var/run/memcached
+  fi
 
-        start_daemon -p /var/run/memcached/memcached_<%= @instance %>.pid /usr/bin/memcached -d \
-          -P /var/run/memcached/memcached_<%= @instance %>.pid <%= @cli_options %>
-        RETVAL=$?
-        echo
-        [ $RETVAL -eq 0 ] && touch <%= @lock_dir %>/memcached
-}
-stop () {
-        echo -n $"Stopping $prog: "
-        killproc -p /var/run/memcached/memcached_<%= @instance %>.pid /usr/local/bin/memcached
-        RETVAL=$?
-        echo
-        if [ $RETVAL -eq 0 ] ; then
-            rm -f <%= @lock_dir %>/memcached
-            rm -f /var/run/memcached/memcached_<%= @instance %>.pid
-        fi
-}
-
-restart () {
-        stop
-        start
-}
-
-
-# See how we were called.
-case "$1" in
-  start)
-        start
-        ;;
-  stop)
-        stop
-        ;;
-  status)
-        status memcached
-        ;;
-  restart|reload|force-reload)
-        restart
-        ;;
-  condrestart)
-        [ -f <%= @lock_dir %>/memcached ] && restart || :
-        ;;
-  *)
-        echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart}"
-        exit 1
+  # Checked the PID file exists and check the actual status of process
+  if [ -e $PIDFILE ]; then
+   status_of_proc -p $PIDFILE $DAEMON "$NAME process" && status="0" || status="$?"
+   # If the status is SUCCESS then don't need to start again.
+   if [ $status = "0" ]; then
+    exit # Exit
+   fi
+  fi
+  # Start the daemon.
+  log_daemon_msg "Starting the process" "$NAME"
+  # Start the daemon with the help of start-stop-daemon
+  # Log the message appropriately
+  if start-stop-daemon -m --start --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON -- -d <%= @cli_options %>; then
+   log_end_msg 0
+  else
+   log_end_msg 1
+  fi
+  ;;
+ stop)
+  # Stop the daemon.
+  if [ -e $PIDFILE ]; then
+   status_of_proc -p $PIDFILE $DAEMON "Stoppping the $NAME process" && status="0" || status="$?"
+   if [ "$status" = 0 ]; then
+    start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+    /bin/rm -rf $PIDFILE
+   fi
+  else
+   log_daemon_msg "$NAME process is not running"
+   log_end_msg 0
+  fi
+  ;;
+ restart)
+  # Restart the daemon.
+  $0 stop && sleep 2 && $0 start
+  ;;
+ status)
+  # Check the status of the process.
+  if [ -e $PIDFILE ]; then
+   status_of_proc -p $PIDFILE $DAEMON "$NAME process" && exit 0 || exit $?
+  else
+   log_daemon_msg "$NAME Process is not running"
+   log_end_msg 0
+  fi
+  ;;
+ reload)
+  # Reload the process. Basically sending some signal to a daemon to reload
+  # it configurations.
+  if [ -e $PIDFILE ]; then
+   start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE --name $NAME
+   log_success_msg "$NAME process reloaded successfully"
+  else
+   log_failure_msg "$PIDFILE does not exists"
+  fi
+  ;;
+ *)
+  # For invalid arguments, print the usage message.
+  echo "Usage: $0 {start|stop|restart|reload|status}"
+  exit 2
+  ;;
 esac
-
-exit $?


### PR DESCRIPTION
Our current init script is platform dependent. This PR gives us a LSB standard script and includes additional testing so we can make sure we can do sys-v everywhere.
