### PR TITLE
Use :template_cookbook property for all template resources

### DIFF
--- a/resources/instance_systemd.rb
+++ b/resources/instance_systemd.rb
@@ -125,7 +125,7 @@ action_class.class_eval do
         binary_path: binary_path,
         cli_options: cli_options
       )
-      cookbook 'memcached'
+      cookbook new_resource.template_cookbook
       notifies :run, 'execute[reload_unit_file]', :immediately
       notifies :restart, "service[#{memcached_instance_name}]", :immediately
       owner 'root'

--- a/resources/instance_sysv_init.rb
+++ b/resources/instance_sysv_init.rb
@@ -117,7 +117,7 @@ action_class.class_eval do
     template "/etc/init.d/#{memcached_instance_name}" do
       mode '0755'
       source 'init_sysv.erb'
-      cookbook 'memcached'
+      cookbook new_resource.template_cookbook
       variables(
         lock_dir: lock_dir,
         instance: memcached_instance_name,

--- a/resources/instance_upstart.rb
+++ b/resources/instance_upstart.rb
@@ -119,7 +119,7 @@ action_class.class_eval do
         ulimit: new_resource.ulimit,
         cli_options: cli_options
       )
-      cookbook 'memcached'
+      cookbook new_resource.template_cookbook
       notifies :restart, "service[#{memcached_instance_name}]", :immediately
     end
   end


### PR DESCRIPTION
There is a `:template_cookbook` property defined on all providers but it's not used by any of them except memcached_instance_runit.

This patch just swaps out the hardcoded `cookbook 'memcached'` for `cookbook new_resource.template_cookbook`.