### PR TITLE
Add missing `user` variable to template in instance_sysv_init resource

### DIFF
--- a/resources/instance_sysv_init.rb
+++ b/resources/instance_sysv_init.rb
@@ -122,6 +122,7 @@ action_class.class_eval do
         lock_dir: lock_dir,
         instance: memcached_instance_name,
         ulimit: new_resource.ulimit,
+        user: new_resource.user,
         cli_options: cli_options
       )
       notifies :restart, "service[#{memcached_instance_name}]", :immediately


### PR DESCRIPTION
The init_sysv.erb template expects `@user` but we don't actually pass it in the template resource. 

Without this, running the init script for memcache instances results in the following error: `chown: missing operand after '/var/run/memcached'`.