### PR TITLE
adding extra_cli_options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/cookstyle --version
   - /opt/chefdk/embedded/bin/foodcritic --version
+  - /opt/chefdk/bin/chef gem install kitchen-dokken
 
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the memcached cookbook.
 
+## 3.0.4 (TBD)
+- Added extra_cli_options so that you can support single item options suchas -L
+
 ## 3.0.3 (2017-01-19)
 
 - Add missing `user` variable to template in instance_sysv_init resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 This file is used to list changes made in each version of the memcached cookbook.
 
-## 3.0.4 (TBD)
-- Added extra_cli_options so that you can support single item options suchas -L
-
 ## 3.0.3 (2017-01-19)
 
 - Add missing `user` variable to template in instance_sysv_init resource

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following are node attributes are used to configure the command line options
 - `memcached['logfilename']` - logfile to which memcached output will be redirected in $logfilepath/$logfilename.
 - `memcached['threads']` - Number of threads to use to process incoming requests. The default is 4.
 - `memcached['experimental_options']` - Comma separated list of extended or experimental options. (array)
+- `memcached['extra_cli_options']` - Array of single item options suchas -L for large pages.
 - `memcached['ulimit']` - maxfile limit to set (needs to be at least maxconn)
 
 ## Usage
@@ -68,7 +69,8 @@ Adds or removes an instance of memcached running under the system's native init 
 - :user - the user to run as
 - :threads - the number of threads to use
 - :max_object_size - the largest object size to store
-- :experimental_options - an array of additional config options
+- :experimental_options - an array of experimental config options, such as: ['maxconns_fast', 'hashpower']
+- :extra_cli_options - an array of additional config options, such as: ['-L']
 - :ulimit - the ulimit setting to use for the service
 - :template_cookbook - the cookbook containing the runit service template. default: memcached
 - :disable_default_instance - disable the default 'memcached' service installed by the package, default: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,7 +28,7 @@ default['memcached']['listen'] = '0.0.0.0'
 default['memcached']['maxconn'] = 1024
 default['memcached']['max_object_size'] = '1m'
 default['memcached']['experimental_options'] = []
-default['memcached']['extra_cli_options'] = ['-L']
+default['memcached']['extra_cli_options'] = []
 default['memcached']['ulimit'] = 1024
 
 default['memcached']['logfilepath'] = '/var/log/'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,7 @@ default['memcached']['listen'] = '0.0.0.0'
 default['memcached']['maxconn'] = 1024
 default['memcached']['max_object_size'] = '1m'
 default['memcached']['experimental_options'] = []
+default['memcached']['extra_cli_options'] = ['-L']
 default['memcached']['ulimit'] = 1024
 
 default['memcached']['logfilepath'] = '/var/log/'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -81,6 +81,7 @@ def cli_options
   end
 
   options << " -t #{new_resource.threads}" if new_resource.threads
+  options << new_resource.extra_cli_options.join(' ')
   options
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -81,7 +81,7 @@ def cli_options
   end
 
   options << " -t #{new_resource.threads}" if new_resource.threads
-  options << new_resource.extra_cli_options.join(' ')
+  options << " #{new_resource.extra_cli_options.join(' ')}"
   options
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,6 +31,7 @@ memcached_instance 'memcached' do
   max_object_size node['memcached']['max_object_size']
   threads node['memcached']['threads']
   experimental_options node['memcached']['experimental_options']
+  extra_cli_options node['memcached']['extra_cli_options']
   ulimit node['memcached']['ulimit']
   action [:start, :enable]
 end

--- a/resources/instance_runit.rb
+++ b/resources/instance_runit.rb
@@ -30,6 +30,7 @@ property :user, String, default: lazy { service_user }
 property :threads, [Integer, String]
 property :max_object_size, String, default: '1m'
 property :experimental_options, Array, default: []
+property :extra_cli_options, Array, default: []
 property :ulimit, [Integer, String], default: 1024
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [TrueClass, FalseClass], default: true

--- a/resources/instance_systemd.rb
+++ b/resources/instance_systemd.rb
@@ -34,6 +34,7 @@ property :user, String, default: lazy { service_user }
 property :threads, [Integer, String]
 property :max_object_size, String, default: '1m'
 property :experimental_options, Array, default: []
+property :extra_cli_options, Array, default: []
 property :ulimit, [Integer, String], default: 1024
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [TrueClass, FalseClass], default: true

--- a/resources/instance_sysv_init.rb
+++ b/resources/instance_sysv_init.rb
@@ -32,6 +32,7 @@ property :user, String, default: lazy { service_user }
 property :threads, [Integer, String]
 property :max_object_size, String, default: '1m'
 property :experimental_options, Array, default: []
+property :extra_cli_options, Array, default: []
 property :ulimit, [Integer, String], default: 1024
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [TrueClass, FalseClass], default: true

--- a/resources/instance_upstart.rb
+++ b/resources/instance_upstart.rb
@@ -35,6 +35,7 @@ property :user, String, default: lazy { service_user }
 property :threads, [Integer, String]
 property :max_object_size, String, default: '1m'
 property :experimental_options, Array, default: []
+property :extra_cli_options, Array, default: []
 property :ulimit, [Integer, String], default: 1024
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [TrueClass, FalseClass], default: true


### PR DESCRIPTION
### Description
This allows for the addition of single item options to memcached suchas  -L

### Issues Resolved

No open issues

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

