### PR TITLE
Just create the log directory according to the specfied log dir attri…

### DIFF
--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -58,3 +58,10 @@ user service_user do
   shell '/bin/false'
   action [:create, :lock]
 end
+
+# create the log directory
+directory node['memcached']['logfilepath'] do
+  owner 'memcache'
+  group 'memcache'
+  mode '0755'
+end


### PR DESCRIPTION
Memcached cookbook doesn't create the logdir according to the specified node attribute, do so here.
