### PR TITLE
Fix logging in cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Adds or removes an instance of memcached running under the system's native init 
 - :ulimit - the ulimit setting to use for the service
 - :template_cookbook - the cookbook containing the runit service template. default: memcached
 - :disable_default_instance - disable the default 'memcached' service installed by the package, default: true
+- :log_level - The level at which we log, default to 'info'. Choose from: 'info', 'debug', 'trace' which map to '-v', '-vv' or '-vvv' arguments.
 
 #### Examples
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,4 @@ default['memcached']['max_object_size'] = '1m'
 default['memcached']['experimental_options'] = []
 default['memcached']['extra_cli_options'] = []
 default['memcached']['ulimit'] = 1024
-
 default['memcached']['logfilepath'] = '/var/log/'
-default['memcached']['logfilename'] = 'memcached.log'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -80,6 +80,17 @@ def cli_options
     options << " -o #{new_resource.experimental_options.join(', ')}"
   end
 
+  log_arg = ''
+  case new_resource.log_level
+  when 'info'
+    log_arg = 'v'
+  when 'debug'
+    log_arg = 'vv'
+  when 'trace'
+    log_arg = 'vvv'
+  end
+  options << " -#{log_arg}"
+
   options << " -t #{new_resource.threads}" if new_resource.threads
   options << " #{new_resource.extra_cli_options.join(' ')}" unless new_resource.extra_cli_options.empty?
   options
@@ -99,4 +110,16 @@ def platform_sysv_init_class
     'debian' => Chef::Provider::Service::Init::Debian,
     'default' => Chef::Provider::Service::Init::Redhat
   )
+end
+
+def log_file_name
+  File.join(node['memcached']['logfilepath'], "#{memcached_instance_name}.log")
+end
+
+def create_log_file
+  file log_file_name do
+    user service_user
+    group service_group
+    mode 00644
+  end
 end

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -58,3 +58,15 @@ user service_user do
   shell '/bin/false'
   action [:create, :lock]
 end
+
+directory node['memcached']['logfilepath'] do
+  user service_user
+  group service_group
+  mode 00755
+end
+
+directory '/var/run/memcached' do
+  user service_user
+  group service_group
+  mode 00755
+end

--- a/resources/instance_runit.rb
+++ b/resources/instance_runit.rb
@@ -33,6 +33,7 @@ property :ulimit, [Integer, String], default: 1024
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [true, false], default: true
 property :remove_default_config, [true, false], default: true
+property :log_level, String, default: 'info'
 
 action :start do
   Chef::Log.warn('The memcached_instance_runit resource has been deprecated as of 9/2017. This resource will be removed in the next major release of the memcached cookbook. We highly recommend using your distributions native init systeam instead.')

--- a/resources/instance_systemd.rb
+++ b/resources/instance_systemd.rb
@@ -39,6 +39,7 @@ property :ulimit, [Integer, String], default: 1024
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [true, false], default: true
 property :remove_default_config, [true, false], default: true
+property :log_level, String, default: 'info'
 
 action :start do
   create_init

--- a/resources/instance_sysv_init.rb
+++ b/resources/instance_sysv_init.rb
@@ -37,6 +37,7 @@ property :ulimit, [Integer, String], default: 1024
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [true, false], default: true
 property :remove_default_config, [true, false], default: true
+property :log_level, String, default: 'info'
 
 action :start do
   create_init
@@ -101,6 +102,9 @@ action_class do
     # the init script will not run without redhat-lsb packages
     package lsb_package if node['platform_family'] == 'rhel'
 
+    # create the log file so we can write to it
+    create_log_file
+
     # remove the debian defaults dir
     file '/etc/default/memcached' do
       action :delete
@@ -115,7 +119,8 @@ action_class do
         instance: memcached_instance_name,
         ulimit: new_resource.ulimit,
         user: new_resource.user,
-        cli_options: cli_options
+        cli_options: cli_options,
+        log_file: log_file_name
       )
       notifies :restart, "service[#{memcached_instance_name}]", :immediately
     end

--- a/resources/instance_upstart.rb
+++ b/resources/instance_upstart.rb
@@ -40,6 +40,7 @@ property :ulimit, [Integer, String], default: 1024
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [true, false], default: true
 property :remove_default_config, [true, false], default: true
+property :log_level, String, default: 'info'
 
 action :start do
   create_init
@@ -108,12 +109,16 @@ action_class do
     # cleanup default configs to avoid confusion
     remove_default_memcached_configs
 
+    # create the log file so we can write to it
+    create_log_file
+
     template "/etc/init/#{memcached_instance_name}.conf" do
       source 'init_upstart.erb'
       variables(
         instance: memcached_instance_name,
         ulimit: new_resource.ulimit,
-        cli_options: cli_options
+        cli_options: cli_options,
+        log_file: log_file_name
       )
       cookbook new_resource.template_cookbook
       notifies :restart, "service[#{memcached_instance_name}]", :immediately

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -30,6 +30,10 @@ describe 'memcached::default' do
     it 'templates /etc/init.d/memcached' do
       expect(chef_run).to create_template('/etc/init.d/memcached')
     end
+
+    it 'creates log file' do
+      expect(chef_run).to create_file('/var/log/memcached.log')
+    end
   end
 
   context 'on rhel 6' do
@@ -54,6 +58,10 @@ describe 'memcached::default' do
     it 'templates /etc/init.d/memcached' do
       expect(chef_run).to create_template('/etc/init.d/memcached')
     end
+
+    it 'creates log file' do
+      expect(chef_run).to create_file('/var/log/memcached.log')
+    end
   end
 
   context 'on ubuntu' do
@@ -69,6 +77,10 @@ describe 'memcached::default' do
 
     it 'deletes /etc/default/memcached' do
       expect(chef_run).to delete_file('/etc/default/memcached')
+    end
+
+    it 'creates log file' do
+      expect(chef_run).to create_file('/var/log/memcached.log')
     end
   end
 end

--- a/templates/init_sysv.erb
+++ b/templates/init_sysv.erb
@@ -46,7 +46,7 @@ start () {
     fi
 
         start_daemon -p /var/run/memcached/memcached_<%= @instance %>.pid /usr/bin/memcached -d \
-          -P /var/run/memcached/memcached_<%= @instance %>.pid <%= @cli_options %>
+          -P /var/run/memcached/memcached_<%= @instance %>.pid <%= @cli_options %> >> <%= @log_file %> 2>&1
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && touch <%= @lock_dir %>/memcached

--- a/templates/init_sysv_debian.erb
+++ b/templates/init_sysv_debian.erb
@@ -41,7 +41,7 @@ do_start()
   start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
     || return 1
   start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
+    $DAEMON_ARGS >> <%= @log_file %> 2>&1 \
     || return 2
 }
 

--- a/templates/init_upstart.erb
+++ b/templates/init_upstart.erb
@@ -7,4 +7,4 @@ respawn limit 10 5
 
 limit nofile <%= @ulimit -%> <%= @ulimit -%>
 
-exec /usr/bin/memcached <%= @cli_options %>
+exec /usr/bin/memcached <%= @cli_options %> >> <%= @log_file %> 2>&1


### PR DESCRIPTION
### Description

Logging in the memcached cookbook is currently broken due to a regression added during refactors and updates, see #78.

This change resolves the issues around logging by:

- Using the `logfilepath` attribute set in the cookbook.
- Having each `memcached_instance` write to a log file using the name of the instance.
- Adding a new `log_level` argument to instances to see verbosity of logging.

### Issues Resolved

This should resolve #78.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
