### PR TITLE
Fix logging directory default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,4 +30,4 @@ default['memcached']['max_object_size'] = '1m'
 default['memcached']['experimental_options'] = []
 default['memcached']['extra_cli_options'] = []
 default['memcached']['ulimit'] = 1024
-default['memcached']['logfilepath'] = '/var/log/'
+default['memcached']['logfilepath'] = '/var/log/memcached'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -32,7 +32,7 @@ describe 'memcached::default' do
     end
 
     it 'creates log file' do
-      expect(chef_run).to create_file('/var/log/memcached.log')
+      expect(chef_run).to create_file('/var/log/memcached/memcached.log')
     end
   end
 
@@ -52,7 +52,7 @@ describe 'memcached::default' do
     end
 
     it 'creates log file' do
-      expect(chef_run).to create_file('/var/log/memcached.log')
+      expect(chef_run).to create_file('/var/log/memcached/memcached.log')
     end
   end
 end


### PR DESCRIPTION
### Description

The `default['memcached']['logfilepath']` attribute that is set as part of the new logging functionality should probably be set to something like `/var/log/memcached`. The directory resource in the _package recipe sets the owner and group of the log directory to the service owner and in the default case it sets the owner and group of `/var/log` to `memcached` which does not follow best practices.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
