### PR TITLE
Use Systemd User directive

### DIFF
--- a/resources/instance_runit.rb
+++ b/resources/instance_runit.rb
@@ -132,8 +132,8 @@ action_class do
       default_logger true
       cookbook new_resource.template_cookbook
       options(
-        user: new_resource.user,
         ulimit: new_resource.ulimit,
+        user: new_resource.user,
         binary_path: binary_path,
         cli_options: cli_options
       )

--- a/resources/instance_systemd.rb
+++ b/resources/instance_systemd.rb
@@ -105,6 +105,7 @@ action_class do
       variables(
         instance: memcached_instance_name,
         ulimit: new_resource.ulimit,
+        user: new_resource.user,
         binary_path: binary_path,
         cli_options: cli_options
       )

--- a/templates/init_systemd.erb
+++ b/templates/init_systemd.erb
@@ -5,6 +5,7 @@ Description=memcached instance <%= @instance %>
 After=network.target
 
 [Service]
+User=<%= @user %>
 LimitNOFILE=<%= @ulimit %>
 ExecStart=<%= @binary_path %> <%= @cli_options %>
 Restart=on-failure


### PR DESCRIPTION
### Description

- Use the 'User' Systemd directive. It is more secure as the
user substitution is done by systemd before memcached execution.
- Note: Systemd can be more restrictive than OS to validate the username

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
