### PR TITLE
Fix experimental_options

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -62,9 +62,7 @@ def cli_options
 -c #{new_resource.maxconn} \
 -I #{new_resource.max_object_size}"
 
-  if new_resource.experimental_options.any?
-    options << " -o #{new_resource.experimental_options.join(',')}"
-  end
+  options << " -o #{new_resource.experimental_options.join(',')}" unless new_resource.experimental_options.empty?
 
   log_arg = ''
   case new_resource.log_level

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -63,7 +63,7 @@ def cli_options
 -I #{new_resource.max_object_size}"
 
   if new_resource.experimental_options.any?
-    options << " -o #{new_resource.experimental_options.join(', ')}"
+    options << " -o #{new_resource.experimental_options.join(',')}"
   end
 
   log_arg = ''


### PR DESCRIPTION
### Description

On memcached command line, experimental options must be separated by commas. Previously we inserted an additional space (', ') so it causes an issue when we set several experimental options.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
