### PR TITLE
Use <%= @binary_path %> consistently

### DIFF
--- a/resources/instance_sysv_init.rb
+++ b/resources/instance_sysv_init.rb
@@ -119,6 +119,7 @@ action_class do
         instance: memcached_instance_name,
         ulimit: new_resource.ulimit,
         user: new_resource.user,
+        binary_path: binary_path,
         cli_options: cli_options,
         log_file: log_file_name
       )

--- a/resources/instance_upstart.rb
+++ b/resources/instance_upstart.rb
@@ -117,6 +117,7 @@ action_class do
       variables(
         instance: memcached_instance_name,
         ulimit: new_resource.ulimit,
+        binary_path: binary_path,
         cli_options: cli_options,
         log_file: log_file_name
       )

--- a/templates/init_sysv.erb
+++ b/templates/init_sysv.erb
@@ -45,7 +45,7 @@ start () {
         chown <%= @user %> /var/run/memcached
     fi
 
-        start_daemon -p /var/run/memcached/memcached_<%= @instance %>.pid /usr/bin/memcached -d \
+        start_daemon -p /var/run/memcached/memcached_<%= @instance %>.pid <%= @binary_path %> -d \
           -P /var/run/memcached/memcached_<%= @instance %>.pid <%= @cli_options %> >> <%= @log_file %> 2>&1
         RETVAL=$?
         echo
@@ -53,7 +53,7 @@ start () {
 }
 stop () {
         echo -n $"Stopping $prog: "
-        killproc -p /var/run/memcached/memcached_<%= @instance %>.pid /usr/bin/memcached
+        killproc -p /var/run/memcached/memcached_<%= @instance %>.pid <%= @binary_path %>
         RETVAL=$?
         echo
         if [ $RETVAL -eq 0 ] ; then

--- a/templates/init_sysv_debian.erb
+++ b/templates/init_sysv_debian.erb
@@ -12,7 +12,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Description of the service"
 NAME=<%= @instance %>
-DAEMON=/usr/bin/memcached
+DAEMON=<%= @binary_path %>
 PIDFILE=/var/run/$NAME.pid
 DAEMON_ARGS="<%= @cli_options %> -d -P $PIDFILE"
 SCRIPTNAME=/etc/init.d/$NAME

--- a/templates/init_upstart.erb
+++ b/templates/init_upstart.erb
@@ -7,4 +7,4 @@ respawn limit 10 5
 
 limit nofile <%= @ulimit -%> <%= @ulimit -%>
 
-exec /usr/bin/memcached <%= @cli_options %> >> <%= @log_file %> 2>&1
+exec <%= @binary_path %> <%= @cli_options %> >> <%= @log_file %> 2>&1


### PR DESCRIPTION
### Description

Commits 623507e and 3771407 add 'binary_path' helper to abstract the
path of memcached. This commit uses it consistently in all start/stop
scripts.
Moreover, I would like the recipe support tarball installation in future. Use consistently binary_path will help to implement it.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
